### PR TITLE
Some additions to StreamDecode/Encode.

### DIFF
--- a/revoice/src/SteamP2PCodec.cpp
+++ b/revoice/src/SteamP2PCodec.cpp
@@ -1,5 +1,9 @@
 #include "precompiled.h"
 
+
+static_assert(sizeof(uint16) == 2,"Sizeof(uint16) should be \"2\". Check your platform");
+
+
 CSteamP2PCodec::CSteamP2PCodec(VoiceEncoder_Silk* backend) {
 	m_BackendCodec = backend;
 }
@@ -20,42 +24,139 @@ bool CSteamP2PCodec::ResetState() {
 int CSteamP2PCodec::StreamDecode(const char *pCompressed, int compressedBytes, char *pUncompressed, int maxUncompressedBytes) const {
 	const char* maxReadPos = pCompressed + compressedBytes;
 	const char* readPos = pCompressed;
-	while (readPos < maxReadPos) {
-		uint8 opcode = *(uint8*)readPos;
+	qboolean DecodingError = FALSE;  
+	int NumDecompressedBytes = 0; 
+
+	auto IsReadValid = [readPos, maxReadPos, &DecodingError](uint16 nShouldRead)->bool
+	{
+		if (readPos + nShouldRead > maxReadPos)
+		{
+			DecodingError = TRUE;
+			return false;
+		}
+		return true;
+	};
+
+	auto IsWriteValid = [NumDecompressedBytes, maxUncompressedBytes, &DecodingError](uint16 nShouldWrite)->bool
+	{
+		if (NumDecompressedBytes + nShouldWrite > maxUncompressedBytes)
+		{
+			DecodingError = TRUE;
+			return false;
+		}
+		return true;
+	};
+
+	uint16 len = 0;
+	while (
+				readPos < maxReadPos && 
+				NumDecompressedBytes<maxUncompressedBytes
+				&&!DecodingError
+			)
+	{
+		auto opcode = *reinterpret_cast<const P2P_PayloadType_e*>(readPos);
 		readPos++;
 
-		switch (opcode) {
-			case 0xB: //Set sampling rate
-				if (readPos + 2 > maxReadPos) {
-					return 0;
-				}
-				readPos += 2;
-				break;
-
-			case 0x04: //Voice payload
+		switch (opcode) 
+		{
+			case P2P_SamplingRate: //Set sampling rate
 			{
-				if (readPos + 2 > maxReadPos) {
-					return 0;
+				if (!IsReadValid(sizeof(uint16)))
+				{
+					break;
 				}
-				uint16 len = *(uint16*)readPos;
-				readPos += 2;
+				readPos += sizeof(uint16);
+				break;
+			}
+			case P2P_Silk: //SILK voice payload
+			{
+				if (!IsReadValid(sizeof(uint16)))
+				{
+					DecodingError = TRUE;
+					break;
+				}
+				len = *(uint16*)readPos;
+				readPos += sizeof(uint16);
 
-				if (readPos + len > maxReadPos) {
-					return 0;
+				if (!IsReadValid(len))
+				{
+					break;
 				}
 				
-				int decompressedLen = m_BackendCodec->Decompress(readPos, len, pUncompressed, maxUncompressedBytes);
-				return decompressedLen;
+				NumDecompressedBytes += (m_BackendCodec->Decompress(readPos, len, &pUncompressed[NumDecompressedBytes], (maxUncompressedBytes - NumDecompressedBytes))*BYTES_PER_SAMPLE);
+				break;
 			}
 
+			case P2P_Raw:
+			{
+				if (!IsReadValid(sizeof(uint16)))
+				{
+					break;
+				}
+				len = *(uint16*)readPos;
+				readPos += sizeof(uint16);
+				if (readPos + len > maxReadPos)
+				{
+					DecodingError = TRUE;
+					break;
+				}
+				if (!IsWriteValid(len))
+				{
+					break;
+				}
+				memmove(&pUncompressed[NumDecompressedBytes], readPos, len);
+				NumDecompressedBytes += len;//Mayby, needs checking for parity?
+				readPos += len;
+				break;
+			}
+
+			case P2P_Unknown2Bytes:
+			{
+				readPos += 2;
+			}
+
+			case P2P_UnknownCodec:
+			case P2P_Speex: //Somebody managed to attach very old steam to new CS. Lol.
+			{
+				//Just ignore it.
+				if (!IsReadValid(sizeof(uint16)))
+				{
+					break;
+				}
+				len = *(uint16*)readPos;
+				readPos += sizeof(uint16);
+				if (!IsReadValid(len))
+				{
+					break;
+				}
+				readPos += len;
+			}
+
+			case P2P_Silence:
+			{
+				if (!IsReadValid(sizeof(uint16)))
+				{
+					break;
+				}
+				len = *(uint16*)readPos*BYTES_PER_SAMPLE; //This is number of samples. Not bytes.
+				readPos += sizeof(uint16);
+				if (!IsWriteValid(len))
+				{
+					break;
+				}
+				memset(&pUncompressed[NumDecompressedBytes], 0, len);
+				//In fact, we should ignore it in the end of packet.
+				NumDecompressedBytes += len;
+			}
 			default: //Invalid or unknown opcode
 				return 0; 
 		}
 	}
 
-	return 0; // no voice payload in the stream
+	return NumDecompressedBytes/BYTES_PER_SAMPLE; 
 }
 
+//#define P2P_UNCOMPRESSED //Just to prove, that Steam users can hear uncompressed voice data.
 int CSteamP2PCodec::StreamEncode(const char *pUncompressedBytes, int nSamples, char *pCompressed, int maxCompressedBytes, bool bFinal) const {
 	char* writePos = pCompressed;
 	if (maxCompressedBytes < 10) { // no room
@@ -65,8 +166,8 @@ int CSteamP2PCodec::StreamEncode(const char *pUncompressedBytes, int nSamples, c
 	*(writePos++) = 0x0B; //set sampling rate
 	*(uint16*)writePos = 16000;
 	writePos += 2;
-
-	*(writePos++) = 0x04; //voice payload
+#ifndef P2P_UNCOMPRESSED
+	*(writePos++) = P2P_Silk; //voice payload
 
 	int compressRes = m_BackendCodec->Compress(pUncompressedBytes, nSamples, writePos + 2, maxCompressedBytes - (1 + 2 + 1 + 2), bFinal);
 	if (compressRes == 0) {
@@ -76,6 +177,17 @@ int CSteamP2PCodec::StreamEncode(const char *pUncompressedBytes, int nSamples, c
 	*(uint16*)writePos = compressRes;
 	writePos += 2;
 	writePos += compressRes;
+#else
+	if (maxCompressedBytes < nSamples*BYTES_PER_SAMPLE + sizeof(P2P_PayloadType_e)){
+		//Buffer too small for uncompressed data.
+		return 0;
+	}
+	*(writePos++) = P2P_Raw; //uncompressed voice payload
+	*(uint16*)writePos = nSamples*BYTES_PER_SAMPLE;
+	writePos += 2;
+	memmove(writePos, pUncompressedBytes, nSamples*BYTES_PER_SAMPLE);
+	writePos += nSamples*BYTES_PER_SAMPLE;
+#endif
 
 	return writePos - pCompressed;
 }

--- a/revoice/src/SteamP2PCodec.h
+++ b/revoice/src/SteamP2PCodec.h
@@ -19,4 +19,21 @@ private:
 	int StreamEncode(const char *pUncompressedBytes, int nSamples, char *pCompressed, int maxCompressedBytes, bool bFinal) const;
 private:
 	VoiceEncoder_Silk* m_BackendCodec;
+
+	enum P2P_PayloadType_e:uint8
+	{
+		P2P_Silence, //Number of empty samples, which should be set to NULL.
+		P2P_UnknownCodec, /*
+								Not used for now. I suppose, it was used for Miles voice data. 
+								Returns "No decoder available, abandoning voice\n" in SteamClient.
+								*/
+		P2P_Speex, /*
+					Not used for now. "No speex decoder available, abandoning voice\n" in SteamClient.
+					In fact, k_EVoiceResultUnsupportedCodec(7) should be returned after it.. but who cares
+					*/
+		P2P_Raw,  //Can be used in theory.    
+		P2P_Silk, 
+		P2P_Unknown2Bytes = 0xA, //Can't understand what for is it, but it's exists in SteamClient.
+		P2P_SamplingRate
+	};
 };


### PR DESCRIPTION
1. Gave some name to opcode numbers.
2. Add some new opcodes.
3. Add ability to send uncompressed data to Steam users. (Just for test, #define should be set)
4. Ruined your code-style in thouse functions. Sorry for that. xD)
5. Not tested on server-side. Only on client.