### PR TITLE
Fix opus

### DIFF
--- a/dep/opus/msvc/Opus.vcxproj
+++ b/dep/opus/msvc/Opus.vcxproj
@@ -222,13 +222,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/dep/opus/silk/define.h
+++ b/dep/opus/silk/define.h
@@ -55,7 +55,8 @@ extern "C"
 
 /* DTX settings */
 #define NB_SPEECH_FRAMES_BEFORE_DTX             10      /* eq 200 ms */
-#define MAX_CONSECUTIVE_DTX                     20      /* eq 400 ms */
+//#define MAX_CONSECUTIVE_DTX                     20      /* eq 400 ms */
+#define MAX_CONSECUTIVE_DTX                     10      /* eq 200 ms */
 
 /* Maximum sampling frequency */
 #define MAX_FS_KHZ                              16

--- a/revoice/src/VoiceEncoder_Opus.cpp
+++ b/revoice/src/VoiceEncoder_Opus.cpp
@@ -132,12 +132,6 @@ int VoiceEncoder_Opus::Compress(const char *pUncompressedIn, int nSamplesIn, cha
 			psRead += FRAME_SIZE * BYTES_PER_SAMPLE;
 			nRemainingSamples--;
 
-			if (nBytes <= 0)
-			{
-				Assert(false);
-				continue;
-			}
-
 			if (nWriteBytes < 2) { // DTX (discontinued transmission)
 				pWritePos = (char*)pWritePayloadSize;
 				*pWritePayloadSize = 0;

--- a/revoice/src/VoiceEncoder_Opus.h
+++ b/revoice/src/VoiceEncoder_Opus.h
@@ -6,8 +6,7 @@
 
 const int MAX_CHANNELS = 1;
 const int FRAME_SIZE = 160;
-const int MAX_FRAME_SIZE = 3 * FRAME_SIZE;
-const int MAX_PACKET_LOSS = 10;
+const int MAX_PACKET_LOSS = 10; // MAX_CONSECUTIVE_DTX
 
 class VoiceEncoder_Opus: public IVoiceCodec {
 private:


### PR DESCRIPTION
- implement DTX correctly
- fix frame size
- fix packet loss

Sending 0 sized payload is not how DTX is implemented in Opus
Instead `opus_encode` can return 1 for maximum of MAX_CONSECUTIVE_DTX frames and it means to transmit nothing
After 10 frames not sent, the 11th frame is not empty but encoded silence frame. Then 10 frames not sent again.

ref: https://www.opus-codec.org/docs/html_api/group__opusencoder.html
`If the return value is 1 byte, then the packet does not need to be transmitted (DTX).`

Receiving end use `opus_decode` with packet loss concealment generating silence with (0, 0) parameters like already implemented, as the DTX packets are "lost".
So `MAX_PACKET_LOSS` must align with `MAX_CONSECUTIVE_DTX`

Also Opus Compress function was non-functioning, `psRead` needs to be advanced for `FRAME_SIZE*2` when you read `FRAME_SIZE*2`, not `MAX_FRAME_SIZE`. But it currently isn't used.

#### Open Questions

There is currently a strange situation with codecs which doesn't really make sense
Currently only two types of client are detected, "speex" and "opus". Not silk, but its still used for compression but not decompression, for which opus is used.
"opus" clients are determined by sv_version cvar engine build >4554 (which also could be silk clients?).

Check the following chart

sender: "vct_speex"
-> for "vct_opus" clients transcoded to Silk -> can be heard by as long as support Silk
->passed as-is to "vct_speex" clients.

sender: "vct_silk"
-> for "opus" gets passed as-is -> can be heard by "vct_opus" client as long as support Silk
-> not transcoded, can't be heard by "vct_speex" clients.

sender: "vct_opus"
-> for "vct_opus" gets passed as-is -> can be heard by "vct_opus" client as long as support Opus_PLC
-> transcoded to Speex for "speex" clients.

So if aim was to use Silk for compatibility purposes, it doesn't quite hit the mark right now.
Because Silk clients are not detected (or detected as "opus"), nor are their packets transcoded to Speex.
Also I don't know if such client version exist with only Opus_PLC support, but those would only be able to speak to Speex/Opus, but only hear other Opus due to their packets received properly as Opus_PLC but when packets are sent to them, Silk is used.

|   sender →<br>receiver ↓  | speex | silk | opus_plc | 
| -------- | :---: | :--: | :--: |
| speex    |   ✅   |  ❌   |     ✅    |
| silk     |   ✅   |   ✅   |     ❌    |
| opus_plc |   ❌   |   ❌  |     ✅    |

Again at least up-to-date Steam clients support both silk and opus_plc so it's not a problem for those clients, but it still doesn't make sense.
I think for maximum compatibility you should either always compress to Silk, which can be heard by all clients supporting Silk.
But if Silk is not to be used, like currently their speech is skipped for Speex clients, shouldn't the compression use opus_PLC like the decompression does?


