### PR TITLE
Update SteamP2PCodec.cpp

### DIFF
--- a/revoice/src/SteamP2PCodec.cpp
+++ b/revoice/src/SteamP2PCodec.cpp
@@ -3,6 +3,7 @@
 CSteamP2PCodec::CSteamP2PCodec(IVoiceCodec *backend)
 {
 	m_BackendCodec = backend;
+	m_Client = nullptr;
 }
 
 bool CSteamP2PCodec::Init(int quality)
@@ -90,7 +91,7 @@ int CSteamP2PCodec::StreamEncode(const char *pUncompressedBytes, int nSamples, c
 	}
 
 	*(writePos++) = PLT_SamplingRate; // Set sampling rate
-	*(uint16 *)writePos = 16000;
+	*(uint16 *)writePos = 8000;
 	writePos += 2;
 
 	*(writePos++) = PLT_Silk; // Voice payload
@@ -130,7 +131,7 @@ int CSteamP2PCodec::Compress(const char *pUncompressedBytes, int nSamples, char 
 	}
 
 	char *writePos = pCompressed;
-	*(uint32 *)writePos = 0x00000011; // steamid (low part)
+	*(uint32 *)writePos = 0x00000011 + (m_Client ? m_Client->GetId() : 0); // steamid (low part)
 	writePos += 4;
 
 	*(uint32 *)writePos = 0x01100001; // steamid (high part)


### PR DESCRIPTION
- differentiate voice packets by adding id (+ 0-31)
- send correct samplerate

## Purpose
Add the client id (0-31) to the lowpart of "steamid" in the voice packet, so the voice packets can be differentiated from each other.
This is likely how steam handles decoding separate audio streams with their own decoder states, and sending everything with same id breaks this.
Also set the samplerate packet to send 8000 to match reality (even though neither opus nor silk use it so it shouldn't really affect anything)

#### Open Questions and Pre-Merge TODOs
The above part is mere speculation how the audio stream separation is handled is merely an educated guess, as the steam API func [DecompressVoice](https://partner.steamgames.com/doc/api/ISteamUser#DecompressVoice) does not have any knowledge of internal game state. The `Voice_AddIncomingData` function that calls it knows which of the five available voice channels the current audio stream is on, but this isn't passed into steam api.
So unless the steam client accesses the game's memory, the only way the api func can differentiate voice packets is by using the information in the packet itself, i.e. the "steamid". This is why its an "educated" guess, but it still is a guess and not confirmed that it is actually how it works.

That all being said, it doesn't exactly hurt either to send the packets with different ids so even if the decoders are not separated like they should and the steamid isnt used.

